### PR TITLE
fix: app select on newly opened windows

### DIFF
--- a/gui_appsetting.go
+++ b/gui_appsetting.go
@@ -115,6 +115,7 @@ func makeAppSettingWindow(settings *Settings, appSetting AppSetting, isNew bool,
 		if slices.Index(windowsForSelect, selected) == -1 {
 			fmt.Println("Selected application no longer exists in the updated window list, resetting selection.")
 			applicationSelect.ClearSelected()
+			return
 		}
 		fmt.Println("Selected Application:", selected)
 		appSetting.WindowName = selected.title
@@ -257,7 +258,7 @@ func makeAppSettingWindow(settings *Settings, appSetting AppSetting, isNew bool,
 				return
 			}
 			fyne.Do(func() {
-				windowsForSelect := getWindowsForSelect(windows)
+				windowsForSelect = getWindowsForSelect(windows)
 				applicationSelect.SetOptions(windowsForSelect)
 
 				if applicationSelect.Selected != nil && slices.Index(windowsForSelect, *applicationSelect.Selected) == -1 {


### PR DESCRIPTION
surprised there's not a "shadowed variable" warning...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of window selection in the application settings dialog to prevent errors when a previously selected window is no longer available.
	- Ensured the window list updates correctly and reflects changes immediately in the selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->